### PR TITLE
Allow multiple graphs based on same RRD file

### DIFF
--- a/custom_components/rrd/camera.py
+++ b/custom_components/rrd/camera.py
@@ -66,7 +66,7 @@ class RRDGraph(Camera):
         self._height = height
         self._timerange = timerange
         self._args = args
-        self._unique_id = self._name
+        self._unique_id = f"rrd_{self._name}"
 
         color = iter(["#00FF00", "#0033FF"])
         self._defs = []
@@ -124,7 +124,7 @@ class RRDGraph(Camera):
     @property
     def name(self) -> str:
         """Return the component name."""
-        return self._name
+        return f"rrd_{self._name}"
 
     @property
     def unique_id(self):

--- a/custom_components/rrd/camera.py
+++ b/custom_components/rrd/camera.py
@@ -66,7 +66,7 @@ class RRDGraph(Camera):
         self._height = height
         self._timerange = timerange
         self._args = args
-        self._unique_id = f"{self._rrd}"  # TODO use also an md5sum of args
+        self._unique_id = self._name
 
         color = iter(["#00FF00", "#0033FF"])
         self._defs = []


### PR DESCRIPTION
**Issue:**

If user want to render two (or more) graphs with same RRD file, then it fails, because both graphs has same unique ID.

**Solution:**

Generate unique ID based on `name` instead of `rrdfile`.