### PR TITLE
rrdgraph: All RRAs are available for 'args'

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This integration is similar to other recorders (e.g. influxdb) but uses [RRDTool](https://oss.oetiker.ch/rrdtool/) as a backend.
 The main benefit of using RRD Recorder is that you can store data for long periods of time without the complexity of adding servers/addon's, unfortunantely it comes with the cost of loss of detailed information for older periods of time (the concept is that you don't need details to the second for data generated a year ago, the average of the day year ago is enough)
 
-Currently this integration records to the RRD database files and has a "Camera" platform that will generate the graphs
+Currently, this integration records to the RRD database files and has a "Camera" platform that will generate the graphs
 
 ## Installation
 
@@ -129,9 +129,36 @@ databases:
 
 ### Camera configuration
 
-The camera component tries to guess everything from the rrd file. But you can always pass new arguments in *args*.
+The camera component tries to guess everything from the rrd file. Alternatively you can always pass new arguments in `args`.
+
+#### `args`
+
+For basic rrd graph, you do not need to make any own configuration in `args`.
+In this case rrd graph will render a line for each datasource of `rrdfile` automatically.
+
+For advanced graph rendering you can use `args` for definitions of parameters CDEF, VDEF, LINE1, ARRAY, etc.
+If you will use own `args` configuration there is automatically generated DEF for each RRA of each datasource.
+
+**Example:**
+
+Rrd file `example1.rrd` has configuration:
+
+    rrdtool create example1.rrd \
+    --step '900' \
+    'DS:temperature:GAUGE:1800:U:U' \
+    'RRA:AVERAGE:0.5:4:48' \
+    'RRA:AVERAGE:0.5:96:365'     
+
+For this `example1.rrd` there are following DEF variables, which you can use in `args`.
+
+- `Temperature`
+- `Temperature_AVERAGE_4`
+- `Temperature_AVERAGE_96`
+
+*Note: As you see in example a `vname` is always a capitalized name of `ds-name`.*
 
 **Hint** use a tool such as [http://rrdwizard.appspot.com/rrdgraph.php](http://rrdwizard.appspot.com/rrdgraph.php)
+
 ```yaml
 name:
   description: Name of the camera entity 

--- a/custom_components/rrd/camera.py
+++ b/custom_components/rrd/camera.py
@@ -92,7 +92,7 @@ class RRDGraph(Camera):
                             rra_pdp_per_row = rrdinfo[f"rra[{rra_index}].pdp_per_row"]
                             rra_cf = rrdinfo[f"rra[{rra_index}].cf"]
                         except:
-                            # Previos RRA what the last in file. Nothing to process.
+                            # Previous RRA was the last in the file. Nothing to process.
                             break
                         rra_step = rra_pdp_per_row * self._step
                         cf = rrdinfo[f"rra[{rra_index}].cf"]

--- a/custom_components/rrd/camera.py
+++ b/custom_components/rrd/camera.py
@@ -87,13 +87,9 @@ class RRDGraph(Camera):
 
                     # Append all other RRAs as DEF with names "{ds.capitalize()}_{rra_cf}_{rra_pdp_per_row}". Example "Temperature_AVERAGE_96".
                     rra_index = 1
-                    while True:
-                        try:
-                            rra_pdp_per_row = rrdinfo[f"rra[{rra_index}].pdp_per_row"]
-                            rra_cf = rrdinfo[f"rra[{rra_index}].cf"]
-                        except:
-                            # Previous RRA was the last in the file. Nothing to process.
-                            break
+                    while f"rra[{rra_index}].cf" in rrdinfo and f"rra[{rra_index}].pdp_per_row" in rrdinfo:
+                        rra_pdp_per_row = rrdinfo[f"rra[{rra_index}].pdp_per_row"]
+                        rra_cf = rrdinfo[f"rra[{rra_index}].cf"]
                         rra_step = rra_pdp_per_row * self._step
                         graph_def = f"DEF:{ds.capitalize()}_{rra_cf}_{rra_pdp_per_row}={rrd}:{ds}:{rra_cf}:step={rra_step}"
                         self._defs.append(graph_def)


### PR DESCRIPTION
Currently, if RRD file has multiple RRA, just the first RRA is available for `args`. Others (mostly long term cumulative) data are unavailable.

**For example:**

I am measuring power conception every 5 minute and storing it for 2 days. I have also second RRA with 24hours cumulative value, which is stored for 5 years. I need also access to second RRA to display long term daily data.

RRD graph tries to select correct RRA based on entered value, but it does not works as expected. So the idea is to provide all RRAs as variables for any further usage in `args`.